### PR TITLE
Fix Wanted Vehicle: Wrong parameter on player's vehicle check

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -18,7 +18,7 @@ function ApplyWantedLevel(level)
                 Citizen.Wait(10)
                 SetPlayerWantedLevel(PlayerId(),newWanted,false)
                 SetPlayerWantedLevelNow(PlayerId(),false)
-                local playerVehicle = GetVehiclePedIsIn(PlayerId(), true)
+                local playerVehicle = GetVehiclePedIsIn(PlayerPedId(), true)
                 if playerVehicle ~= 0 then
                     SetVehicleIsWanted(playerVehicle, true)
                 end


### PR DESCRIPTION
GetVehiclePedIsIn native functions requests player ped id as the first parameter instead of player id.